### PR TITLE
Add /random route, which responds with a random card object

### DIFF
--- a/gatherer.coffee
+++ b/gatherer.coffee
@@ -40,3 +40,8 @@ exports.fetch_set = (params, callback) ->
   request {url}, (error, response, body) ->
     parser.set body, {page}, callback
   return
+
+exports.random_card = (callback) ->
+  url = gatherer_url + 'Card/Details.aspx?action=random'
+  request {url}, (error, response, body) ->
+    parser.card body, {gid_attributes: true}, callback

--- a/parser.coffee
+++ b/parser.coffee
@@ -131,6 +131,9 @@ gid_specific_attrs =
   artist: ($) ->
     $('Artist')[0]?.text
 
+  gatherer_url: ($, data, jQuery) ->
+    jQuery('#aspnetForm')[0].action
+
 get_gatherer_id = ($) ->
   # Abuse the fact that `[123]` can be coerced to `123`.
   +/\d+$/.exec $('.cardTitle').find('a').attr('href')

--- a/server.coffee
+++ b/server.coffee
@@ -20,6 +20,7 @@ set_handler = (req, res) ->
   api.fetch_set req.params, build_responder req, res
 
 app = express.createServer()
+app.get '/card/random', (req, res) -> api.random_card build_responder req, res
 app.get /// ^/card/(\d+)(?:/(\w+))?/?$ ///, card_handler
 app.get '/card/:name', card_handler
 app.get '/set/:name/:page?', set_handler


### PR DESCRIPTION
In order for this to work, parser.card had to learn how to find a card's gatherer id without it being explicitly passed as an option.
