### PR TITLE
remove entire column for transforming cards

### DIFF
--- a/parser.coffee
+++ b/parser.coffee
@@ -200,7 +200,7 @@ exports.card = (body, callback) ->
       prefix = id = '#ctl00_ctl00_ctl00_MainContent_SubContent_SubContent'
       title1 = jQuery(prefix + 'Header_subtitleDisplay')[0].text
       title2 = jQuery(prefix + '_ctl06_nameRow').children('.value')[0]?.text
-      id += if title1 is title2 then '_ctl05_rightCol' else '_cardComponent1'
+      id += if title1 is title2 then '_cardComponent0' else '_cardComponent1'
       jQuery(id).remove()
 
       $ = (label) -> jQuery('.label').filter(-> @text is label + ':').next()

--- a/test/fixtures/cards.coffee
+++ b/test/fixtures/cards.coffee
@@ -16,7 +16,6 @@ exports.recall =
     """
     expansion: 'Legends'
     rarity: 'Rare'
-    number: 46
     artist: 'Brian Snoddy'
     gatherer_url:
       'http://gatherer.wizards.com/Pages/Card/Details.aspx?multiverseid=1496'
@@ -642,29 +641,4 @@ exports.ransacker =
     rarity: 'Uncommon'
     number: '81b'
     artist: 'David Palumbo'
-    rulings: [
-      ['2011-01-22', __ """
-        You choose the target artifact when Werewolf Ransacker's first
-        triggered ability goes on the stack. You choose whether or not to
-        destroy the artifact when that ability resolves.
-      """]
-      ['2011-01-22', __ """
-        If the targeted artifact is indestructible or regenerates (or you
-        choose not to destroy it), Werewolf Ransacker doesn't deal damage to
-        that artifact's controller. Similarly, if the targeted artifact is
-        destroyed but a replacement effect moves it to a different zone
-        instead of its owner's graveyard, Werewolf Ransacker doesn't deal
-        damage to that artifact's controller.
-      """]
-      ['2011-01-22', __ """
-        An artifact token that's destroyed is put into its owner's graveyard
-        before it ceases to exist. If a token is destroyed by Werewolf
-        Ransacker ability, Werewolf Ransacker deals damage to that token's
-        controller.
-      """]
-      ['2011-01-22', __ """
-        If something becomes a copy of Werewolf Ransacker, that doesn't count
-        as "transforming into Werewolf Ransacker." The first triggered ability
-        of the new Werewolf Ransacker doesn't trigger.
-      """]
-    ]
+    rulings: []


### PR DESCRIPTION
I was wrong: looking at more cards (for example http://gatherer.wizards.com/Pages/Card/Details.aspx?name=Garruk,%20The%20Veil-Cursed), it seems that transforming cards are supposed to have rulings associated with the particular side they relate to, but some (including afflicted deserter/ransacker werewolf) just put everything on the left column.
