### PR TITLE
fix: localised quotation marks parsing

### DIFF
--- a/parser.coffee
+++ b/parser.coffee
@@ -150,7 +150,7 @@ gid_specific_attrs =
     if match = /^(\u2014|\u2015\u2015|\uFF5E)(.+)$/.exec @text el
       data.flavor_text_attribution = match[2]
       el.remove()
-    /^"(.+)"$/.exec(text = @text flavor)?[1] or text
+    /^[„"«「](.+)["»」]$/.exec(text = @text flavor)?[1] or text
 
   hand_modifier: vanguard_modifier /Hand Modifier: ([+-]\d+)/
 

--- a/test/fixtures/cards.coffee
+++ b/test/fixtures/cards.coffee
@@ -776,7 +776,7 @@ exports.birds_of_paradise_ja =
         rarity: 'Rare'
     rulings: []
     gatherer_url: 'http://gatherer.wizards.com/Pages/Card/Details.aspx?printed=true&multiverseid=264287'
-    flavor_text: '「神様はその鳥の羽根で、世界中の色を塗り上げたのです。」'
+    flavor_text: '神様はその鳥の羽根で、世界中の色を塗り上げたのです。'
     flavor_text_attribution: 'グラマー森の保護者、イェイラ＝ティヴァ'
     expansion: 'Magic 2012'
     rarity: 'Rare'
@@ -844,7 +844,7 @@ exports.birds_of_paradise_zh_cn =
         rarity: 'Rare'
     rulings: []
     gatherer_url: 'http://gatherer.wizards.com/Pages/Card/Details.aspx?printed=true&multiverseid=263291'
-    flavor_text: '「神明用牠們的羽毛來為世界著色。」'
+    flavor_text: '神明用牠們的羽毛來為世界著色。'
     flavor_text_attribution: '格拉莫樹林守衛葉提娃'
     expansion: 'Magic 2012'
     rarity: 'Rare'
@@ -912,7 +912,7 @@ exports.birds_of_paradise_zh_tw =
         rarity: 'Rare'
     rulings: []
     gatherer_url: 'http://gatherer.wizards.com/Pages/Card/Details.aspx?printed=true&multiverseid=263042'
-    flavor_text: '「神明用他们的羽毛来为世界着色。」'
+    flavor_text: '神明用他们的羽毛来为世界着色。'
     flavor_text_attribution: '格拉莫树林守卫叶提娃'
     expansion: 'Magic 2012'
     rarity: 'Rare'


### PR DESCRIPTION
I added support for localised quotation marks, tutor now remove the quotes in all languages.
I am not sure if this is a good idea, but at least now is consistent.
