### PR TITLE
add image_url to card responses

### DIFF
--- a/parser.coffee
+++ b/parser.coffee
@@ -1,8 +1,8 @@
 cheerio   = require 'cheerio'
 entities  = require 'entities'
 
-
-gatherer_root = 'http://gatherer.wizards.com/Pages/'
+gatherer_host = 'http://gatherer.wizards.com/'
+gatherer_root = gatherer_host + 'Pages/'
 
 prefix = '#ctl00_ctl00_ctl00_MainContent_SubContent_SubContent'
 
@@ -103,6 +103,21 @@ common_attrs =
 
   watermark: ->
     @text 'Watermark'
+
+  image_url: ->
+    try
+      # best method, does not work on cards fetched by name
+      gatherer_id = @$('#aspnetForm').attr('action').match(/\=(\d+)/)[1]
+    catch error
+      console.log error
+      # next-best, does not work on transforming cards or cards in other languages
+      set_symbol_div = @$(prefix + '_currentSetSymbol')
+      set_symbol_anchor = set_symbol_div.children().first()
+      set_symbol_link = set_symbol_anchor.attr('href')
+      gatherer_id = +/\=(\d+)/.exec(set_symbol_link)[1]
+
+    gatherer_host + "Handlers/Image.ashx?multiverseid=#{gatherer_id}&type=card"
+
 
   stats: (data) ->
     return unless text = @text 'P/T'

--- a/test/fixtures/cards/aether_storm.coffee
+++ b/test/fixtures/cards/aether_storm.coffee
@@ -13,6 +13,8 @@ response:
   """
   gatherer_url:
     'http://gatherer.wizards.com/Pages/Card/Details.aspx?name=%u00c6ther+Storm'
+  image_url:
+    'http://gatherer.wizards.com/Handlers/Image.ashx?multiverseid=184722&type=card'
   versions:
     2935:
       expansion: 'Homelands'

--- a/test/fixtures/cards/afflicted_deserter.coffee
+++ b/test/fixtures/cards/afflicted_deserter.coffee
@@ -20,6 +20,8 @@ response:
   artist: 'David Palumbo'
   gatherer_url:
     'http://gatherer.wizards.com/Pages/Card/Details.aspx?multiverseid=262675'
+  image_url:
+    'http://gatherer.wizards.com/Handlers/Image.ashx?multiverseid=262675&type=card'
   versions:
     262675:
       expansion: 'Dark Ascension'

--- a/test/fixtures/cards/ajani_goldmane.coffee
+++ b/test/fixtures/cards/ajani_goldmane.coffee
@@ -22,6 +22,8 @@ response:
   artist: 'Aleksi Briclot'
   gatherer_url:
     'http://gatherer.wizards.com/Pages/Card/Details.aspx?multiverseid=140233'
+  image_url:
+    'http://gatherer.wizards.com/Handlers/Image.ashx?multiverseid=140233&type=card'
   versions:
     140233:
       expansion: 'Lorwyn'

--- a/test/fixtures/cards/akroma_angel_of_wrath_avatar.coffee
+++ b/test/fixtures/cards/akroma_angel_of_wrath_avatar.coffee
@@ -17,6 +17,8 @@ response:
   rulings: []
   gatherer_url:
     'http://gatherer.wizards.com/Pages/Card/Details.aspx?multiverseid=182290'
+  image_url:
+    'http://gatherer.wizards.com/Handlers/Image.ashx?multiverseid=182290&type=card'
   flavor_text: __ """
     "Chuck's Virtual Party" avatar (2003)
   """

--- a/test/fixtures/cards/akroma_angel_of_wrath_de.coffee
+++ b/test/fixtures/cards/akroma_angel_of_wrath_de.coffee
@@ -24,6 +24,8 @@ response:
   rulings: []
   gatherer_url:
     'http://gatherer.wizards.com/Pages/Card/Details.aspx?multiverseid=131257&printed=true'
+  image_url:
+    'http://gatherer.wizards.com/Handlers/Image.ashx?multiverseid=131257&type=card'
   flavor_text: '„Keine Ruhepause. Keine Gnade. Egal was geschieht."'
   expansion: 'Time Spiral "Timeshifted"'
   rarity: 'Special'

--- a/test/fixtures/cards/ancestral_vision.coffee
+++ b/test/fixtures/cards/ancestral_vision.coffee
@@ -19,6 +19,8 @@ response:
   artist: 'Mark Poole'
   gatherer_url:
     'http://gatherer.wizards.com/Pages/Card/Details.aspx?multiverseid=113505'
+  image_url:
+    'http://gatherer.wizards.com/Handlers/Image.ashx?multiverseid=113505&type=card'
   versions:
     113505:
       expansion: 'Time Spiral'

--- a/test/fixtures/cards/anhavva_constable.coffee
+++ b/test/fixtures/cards/anhavva_constable.coffee
@@ -21,6 +21,8 @@ response:
   artist: 'Dan Frazier'
   gatherer_url:
     'http://gatherer.wizards.com/Pages/Card/Details.aspx?multiverseid=2960'
+  image_url:
+    'http://gatherer.wizards.com/Handlers/Image.ashx?multiverseid=2960&type=card'
   versions:
     2960:
       expansion: 'Homelands'

--- a/test/fixtures/cards/birds_of_paradise_de.coffee
+++ b/test/fixtures/cards/birds_of_paradise_de.coffee
@@ -58,6 +58,8 @@ response:
   rulings: []
   gatherer_url:
     'http://gatherer.wizards.com/Pages/Card/Details.aspx?multiverseid=263789&printed=true'
+  image_url:
+    'http://gatherer.wizards.com/Handlers/Image.ashx?multiverseid=263789&type=card'
   flavor_text: __ """
     Ihre Federn dienten den Göttern, um die Welt farbig anzustreichen.
   """

--- a/test/fixtures/cards/birds_of_paradise_fr.coffee
+++ b/test/fixtures/cards/birds_of_paradise_fr.coffee
@@ -58,6 +58,8 @@ response:
   rulings: []
   gatherer_url:
     'http://gatherer.wizards.com/Pages/Card/Details.aspx?printed=true&multiverseid=263540'
+  image_url:
+    'http://gatherer.wizards.com/Handlers/Image.ashx?multiverseid=263540&type=card'
   flavor_text: __ """
     Les dieux ont utilisé leurs plumes pour peindre toutes les couleurs du
     monde.

--- a/test/fixtures/cards/birds_of_paradise_ja.coffee
+++ b/test/fixtures/cards/birds_of_paradise_ja.coffee
@@ -58,6 +58,8 @@ response:
   rulings: []
   gatherer_url:
     'http://gatherer.wizards.com/Pages/Card/Details.aspx?printed=true&multiverseid=264287'
+  image_url:
+    'http://gatherer.wizards.com/Handlers/Image.ashx?multiverseid=264287&type=card'
   flavor_text: '神様はその鳥の羽根で、世界中の色を塗り上げたのです。'
   flavor_text_attribution: 'グラマー森の保護者、イェイラ＝ティヴァ'
   expansion: 'Magic 2012'

--- a/test/fixtures/cards/birds_of_paradise_ru.coffee
+++ b/test/fixtures/cards/birds_of_paradise_ru.coffee
@@ -58,6 +58,8 @@ response:
   rulings: []
   gatherer_url:
     'http://gatherer.wizards.com/Pages/Card/Details.aspx?printed=true&multiverseid=264785'
+  image_url:
+    'http://gatherer.wizards.com/Handlers/Image.ashx?multiverseid=264785&type=card'
   flavor_text_attribution: 'Яре-Тива, хранительница Грамурского леса'
   flavor_text: 'Их перьями боги расписывали красочную картину мира.'
   expansion: 'Magic 2012'

--- a/test/fixtures/cards/birds_of_paradise_zh_cn.coffee
+++ b/test/fixtures/cards/birds_of_paradise_zh_cn.coffee
@@ -58,6 +58,8 @@ response:
   rulings: []
   gatherer_url:
     'http://gatherer.wizards.com/Pages/Card/Details.aspx?printed=true&multiverseid=263291'
+  image_url: 
+    'http://gatherer.wizards.com/Handlers/Image.ashx?multiverseid=263291&type=card'
   flavor_text: '神明用牠們的羽毛來為世界著色。'
   flavor_text_attribution: '格拉莫樹林守衛葉提娃'
   expansion: 'Magic 2012'

--- a/test/fixtures/cards/birds_of_paradise_zh_tw.coffee
+++ b/test/fixtures/cards/birds_of_paradise_zh_tw.coffee
@@ -59,6 +59,8 @@ exports.birds_of_paradise_zh_tw =
     rulings: []
     gatherer_url:
       'http://gatherer.wizards.com/Pages/Card/Details.aspx?printed=true&multiverseid=263042'
+    image_url:
+      'http://gatherer.wizards.com/Handlers/Image.ashx?multiverseid=263042&type=card'
     flavor_text: '神明用他们的羽毛来为世界着色。'
     flavor_text_attribution: '格拉莫树林守卫叶提娃'
     expansion: 'Magic 2012'

--- a/test/fixtures/cards/canyon_minotaur.coffee
+++ b/test/fixtures/cards/canyon_minotaur.coffee
@@ -23,6 +23,8 @@ response:
   rulings: []
   gatherer_url:
     'http://gatherer.wizards.com/Pages/Card/Details.aspx?multiverseid=259211'
+  image_url:
+    'http://gatherer.wizards.com/Handlers/Image.ashx?multiverseid=259211&type=card'
   flavor_text: """
     "We'll scale these cliffs, traverse Brittle Bridge, and then fight our way down the volcanic slopes on the other side."
     "Isn't the shortest route through the canyon?"

--- a/test/fixtures/cards/cardpecker.coffee
+++ b/test/fixtures/cards/cardpecker.coffee
@@ -20,6 +20,8 @@ response:
   rulings: []
   gatherer_url:
     'http://gatherer.wizards.com/Pages/Card/Details.aspx?multiverseid=74244'
+  image_url:
+    'http://gatherer.wizards.com/Handlers/Image.ashx?multiverseid=74244&type=card'
   expansion: 'Unhinged'
   rarity: 'Common'
   number: 4

--- a/test/fixtures/cards/cheap_ass.coffee
+++ b/test/fixtures/cards/cheap_ass.coffee
@@ -16,6 +16,8 @@ response:
   rulings: []
   gatherer_url:
     'http://gatherer.wizards.com/Pages/Card/Details.aspx?multiverseid=74220'
+  image_url:
+    'http://gatherer.wizards.com/Handlers/Image.ashx?multiverseid=74220&type=card'
   expansion: 'Unhinged'
   rarity: 'Common'
   number: 5

--- a/test/fixtures/cards/crackleburr.coffee
+++ b/test/fixtures/cards/crackleburr.coffee
@@ -46,6 +46,8 @@ response:
   ]
   gatherer_url:
     'http://gatherer.wizards.com/Pages/Card/Details.aspx?multiverseid=157420'
+  image_url:
+    'http://gatherer.wizards.com/Handlers/Image.ashx?multiverseid=157420&type=card'
   expansion: 'Eventide'
   rarity: 'Rare'
   number: 100

--- a/test/fixtures/cards/darksteel_colossus.coffee
+++ b/test/fixtures/cards/darksteel_colossus.coffee
@@ -22,6 +22,8 @@ response:
   artist: 'Carl Critchlow'
   gatherer_url:
     'http://gatherer.wizards.com/Pages/Card/Details.aspx?multiverseid=191312'
+  image_url:
+    'http://gatherer.wizards.com/Handlers/Image.ashx?multiverseid=191312&type=card'
   versions:
     48158:
       expansion: 'Darksteel'

--- a/test/fixtures/cards/diamond_faerie.coffee
+++ b/test/fixtures/cards/diamond_faerie.coffee
@@ -24,6 +24,8 @@ response:
   artist: 'Heather Hudson'
   gatherer_url:
     'http://gatherer.wizards.com/Pages/Card/Details.aspx?multiverseid=121138'
+  image_url:
+    'http://gatherer.wizards.com/Handlers/Image.ashx?multiverseid=121138&type=card'
   versions:
     121138:
       expansion: 'Coldsnap'

--- a/test/fixtures/cards/fire.coffee
+++ b/test/fixtures/cards/fire.coffee
@@ -26,3 +26,5 @@ response:
   artist: 'Franz Vohwinkel'
   gatherer_url:
     'http://gatherer.wizards.com/Pages/Card/Details.aspx?part=Fire&multiverseid=27166'
+  image_url:
+    'http://gatherer.wizards.com/Handlers/Image.ashx?multiverseid=27166&type=card'

--- a/test/fixtures/cards/flame_javelin.coffee
+++ b/test/fixtures/cards/flame_javelin.coffee
@@ -21,6 +21,8 @@ response:
   artist: 'Trevor Hairsine'
   gatherer_url:
     'http://gatherer.wizards.com/Pages/Card/Details.aspx?multiverseid=146017'
+  image_url:
+    'http://gatherer.wizards.com/Handlers/Image.ashx?multiverseid=146017&type=card'
   versions:
     146017:
       expansion: 'Shadowmoor'

--- a/test/fixtures/cards/hill_giant.coffee
+++ b/test/fixtures/cards/hill_giant.coffee
@@ -45,6 +45,8 @@ response:
   rulings: []
   gatherer_url:
     'http://gatherer.wizards.com/Pages/Card/Details.aspx?multiverseid=129591'
+  image_url:
+    'http://gatherer.wizards.com/Handlers/Image.ashx?multiverseid=129591&type=card'
   flavor_text: __ """
     Fortunately, hill giants have large blind spots in which a human
     can easily hide. Unfortunately, these blind spots are beneath the

--- a/test/fixtures/cards/ice.coffee
+++ b/test/fixtures/cards/ice.coffee
@@ -16,6 +16,8 @@ response:
   artist: 'Franz Vohwinkel'
   gatherer_url:
     'http://gatherer.wizards.com/Pages/Card/Details.aspx?part=Ice&multiverseid=27166'
+  image_url:
+    'http://gatherer.wizards.com/Handlers/Image.ashx?multiverseid=27166&type=card'
   versions:
     27165:
       expansion: 'Apocalypse'

--- a/test/fixtures/cards/phantasmal_sphere.coffee
+++ b/test/fixtures/cards/phantasmal_sphere.coffee
@@ -21,6 +21,8 @@ response:
   toughness: 1
   gatherer_url:
     'http://gatherer.wizards.com/Pages/Card/Details.aspx?name=Phantasmal+Sphere'
+  image_url:
+    'http://gatherer.wizards.com/Handlers/Image.ashx?multiverseid=3113&type=card'
   versions:
     3113:
       expansion: 'Alliances'

--- a/test/fixtures/cards/recall.coffee
+++ b/test/fixtures/cards/recall.coffee
@@ -14,6 +14,8 @@ response:
   artist: 'Brian Snoddy'
   gatherer_url:
     'http://gatherer.wizards.com/Pages/Card/Details.aspx?multiverseid=1496'
+  image_url:
+    'http://gatherer.wizards.com/Handlers/Image.ashx?multiverseid=1496&type=card'
   versions:
     1496:
       expansion: 'Legends'

--- a/test/fixtures/cards/serrated_arrows.coffee
+++ b/test/fixtures/cards/serrated_arrows.coffee
@@ -17,6 +17,8 @@ response:
   """
   gatherer_url:
     'http://gatherer.wizards.com/Pages/Card/Details.aspx?name=Serrated+Arrows'
+  image_url:
+    'http://gatherer.wizards.com/Handlers/Image.ashx?multiverseid=202280&type=card'
   versions:
     2909:
       expansion: 'Homelands'

--- a/test/fixtures/cards/tunnel.coffee
+++ b/test/fixtures/cards/tunnel.coffee
@@ -26,6 +26,8 @@ response:
       rarity: 'Uncommon'
   gatherer_url:
     'http://gatherer.wizards.com/Pages/Card/Details.aspx?printed=true&multiverseid=226'
+  image_url:
+    'http://gatherer.wizards.com/Handlers/Image.ashx?multiverseid=226&type=card'
   expansion: 'Limited Edition Alpha'
   rarity: 'Uncommon'
   artist: 'Dan Frazier'

--- a/test/fixtures/cards/vault_skirge.coffee
+++ b/test/fixtures/cards/vault_skirge.coffee
@@ -26,6 +26,8 @@ response:
   artist: 'Brad Rigney'
   gatherer_url:
     'http://gatherer.wizards.com/Pages/Card/Details.aspx?multiverseid=217984'
+  image_url:
+    'http://gatherer.wizards.com/Handlers/Image.ashx?multiverseid=217984&type=card'
   versions:
     217984:
       expansion: 'New Phyrexia'

--- a/test/fixtures/cards/werewolf_ransacker.coffee
+++ b/test/fixtures/cards/werewolf_ransacker.coffee
@@ -21,6 +21,8 @@ response:
       rarity: 'Uncommon'
   gatherer_url:
     'http://gatherer.wizards.com/Pages/Card/Details.aspx?multiverseid=262698'
+  image_url:
+    'http://gatherer.wizards.com/Handlers/Image.ashx?multiverseid=262698&type=card'
   expansion: 'Dark Ascension'
   rarity: 'Uncommon'
   number: '81b'


### PR DESCRIPTION
The urls are built from a gatherer id, which can be found on every page, even the search-by-name ones.

Should the server respond to card/[:id].jpg?
