### PR TITLE
Include multiverse ID in cards in set listing

### DIFF
--- a/parser.coffee
+++ b/parser.coffee
@@ -277,6 +277,7 @@ exports.set = (body, callback) ->
         href = el.find('.cardTitle').find('a').attr('href')
         [param, id] = /multiverseid=(\d+)/.exec href
         params = '?' + param
+        card.multiverse_id = parseInt(id)
         card.gatherer_url = gatherer_base_card_url + params
         card.image_url = gatherer_image_handler + params + '&type=card'
 


### PR DESCRIPTION
In `GET /set/:name(/:page)` it might be useful to know the multiverse ID of a card's specific version that is included in that set, without having to parse that card's versions. This is as opposed to requesting a card by its multiverse ID, in which case the multiverse ID is already known; or requesting a card by its name, without caring about a specific version and being able to see all of the versions with their multiverse IDs.
