### PR TITLE
gatherer.request: fix handling of three or more arguments

### DIFF
--- a/lib/gatherer.js
+++ b/lib/gatherer.js
@@ -41,6 +41,8 @@
     args = 1 <= arguments.length ? __slice.call(arguments, 0) : [];
     if (args.length >= 3) {
       uri = args[0], options = args[1], callback = args[2];
+      options = JSON.parse(JSON.stringify(options));
+      options.uri = uri;
     } else if (Object.prototype.toString.call(args[0]) === '[object String]') {
       uri = args[0], callback = args[1];
       options = {

--- a/src/gatherer.coffee
+++ b/src/gatherer.coffee
@@ -18,6 +18,8 @@ gatherer.url = (pathname, query = {}) ->
 gatherer.request = (args...) ->
   if args.length >= 3
     [uri, options, callback] = args
+    options = JSON.parse JSON.stringify options
+    options.uri = uri
   else if Object::toString.call(args[0]) is '[object String]'
     [uri, callback] = args
     options = {uri}


### PR DESCRIPTION
I happened to notice this error, introduced in #74, while working on a fix for another issue. The three-argument form is not currently used, but should be fixed regardless.
