### PR TITLE
makefile: integrate xyz

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,6 @@
     "coffee-script": "1.7.x",
     "mocha": "1.17.x",
     "nock": "0.42.x",
-    "semver": "2.2.x"
+    "xyz": "0.4.x"
   }
 }

--- a/scripts/prepublish
+++ b/scripts/prepublish
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -e
+
+LIB=$(find src -name '*.coffee' -exec sh -c 'sed "s:^src/\(.*\)\.coffee$:lib/\1.js:" <<<"{}"' \;)
+
+rm -f                                   -- $LIB
+make                                    -- $LIB
+git update-index --no-assume-unchanged  -- $LIB
+git add                                 -- $LIB
+git update-index --assume-unchanged     -- $LIB


### PR DESCRIPTION
Closes #83

This pull request integrates [xyz](https://github.com/davidchambers/xyz) to further automate the release process. It also introduces a prepublish script (run by xyz, not npm) which generates the JavaScript files. This means it's no longer necessary to include the JavaScript files when committing changes. Thanks to `git update-index --assume-unchanged` (which is run as part of `make setup`) changes to JavaScript files do not appear in the output of `git status`.
