### PR TITLE
Update check for "No Results" when searching by name

### DIFF
--- a/lib/gatherer.js
+++ b/lib/gatherer.js
@@ -58,7 +58,7 @@
         return callback(err);
       } else if (res.statusCode !== 200) {
         return callback(new Error('unexpected status code'));
-      } else if (body.indexOf('<title>Object moved</title>') >= 0) {
+      } else if (body.indexOf('<div class="cardImage">') == -1) {
         return callback(new Error('no results'));
       } else {
         return callback(null, res, body);


### PR DESCRIPTION
Since Gatherer has had it's formatting updated recently, checking to see
if a html tag exclusive to a card result page will allow the exception to
be caught again.