### PR TITLE
respond with "no results" given non-existent card name

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,5 @@ node_js:
   - "0.11"
   - "0.10"
 install: npm install
-before_script: make fixtures
+before_script: make clean fixtures
 script: make test testcli

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ lib/%.js: src/%.coffee
 fixtures: $(FIXTURES)
 
 test/fixtures/%.html: test/fixtures/%
-	xargs curl --silent -- <$< >$@
+	xargs curl --location --silent -- <$< >$@
 
 
 .PHONY: clean

--- a/src/gatherer.coffee
+++ b/src/gatherer.coffee
@@ -32,8 +32,6 @@ gatherer.request = (args...) ->
       callback err
     else if res.statusCode isnt 200
       callback new Error 'unexpected status code'
-    else if body.indexOf('<title>Object moved</title>') >= 0
-      callback new Error 'no results'
     else
       callback null, res, body
 

--- a/src/gatherer/card.coffee
+++ b/src/gatherer/card.coffee
@@ -13,7 +13,11 @@ module.exports = (details, callback) ->
     if err?
       callback err
     else
-      callback null, extract cheerio.load(body), details
+      $ = cheerio.load body
+      if $('title').text().trim().indexOf('Card Search - Search:') is 0
+        callback new Error 'no results'
+      else
+        callback null, extract $, details
     return
   return
 


### PR DESCRIPTION
Fixes #93

#92 was not a suitable fix. The tests passed (erroneously) because the command for creating fixtures was missing the `--location` flag for following redirects.

@CBXZero, could you verify that this change works for you?
