### PR TITLE
recognize colorless mana symbol

### DIFF
--- a/src/symbols.coffee
+++ b/src/symbols.coffee
@@ -8,6 +8,7 @@ module.exports = _.invert
   'R': 'Red'
   'G': 'Green'
   '2': 'Two'
+  'C': 'Colorless'
   'S': 'Snow'
   'T': 'Tap'
   'Q': 'Untap'

--- a/test/fixtures/cards/kozilek-the-great-distortion~details
+++ b/test/fixtures/cards/kozilek-the-great-distortion~details
@@ -1,0 +1,1 @@
+http://gatherer.wizards.com/Pages/Card/Details.aspx?name=Kozilek%2C%20the%20Great%20Distortion

--- a/test/fixtures/cards/kozilek-the-great-distortion~languages
+++ b/test/fixtures/cards/kozilek-the-great-distortion~languages
@@ -1,0 +1,1 @@
+http://gatherer.wizards.com/Pages/Card/Languages.aspx?name=Kozilek%2C%20the%20Great%20Distortion

--- a/test/fixtures/cards/kozilek-the-great-distortion~printings
+++ b/test/fixtures/cards/kozilek-the-great-distortion~printings
@@ -1,0 +1,1 @@
+http://gatherer.wizards.com/Pages/Card/Printings.aspx?name=Kozilek%2C%20the%20Great%20Distortion

--- a/test/fixtures/cards/sol-ring~details
+++ b/test/fixtures/cards/sol-ring~details
@@ -1,0 +1,1 @@
+http://gatherer.wizards.com/Pages/Card/Details.aspx?name=Sol%20Ring

--- a/test/fixtures/cards/sol-ring~languages
+++ b/test/fixtures/cards/sol-ring~languages
@@ -1,0 +1,1 @@
+http://gatherer.wizards.com/Pages/Card/Languages.aspx?name=Sol%20Ring

--- a/test/fixtures/cards/sol-ring~printings
+++ b/test/fixtures/cards/sol-ring~printings
@@ -1,0 +1,1 @@
+http://gatherer.wizards.com/Pages/Card/Printings.aspx?name=Sol%20Ring

--- a/test/tutor.coffee
+++ b/test/tutor.coffee
@@ -361,6 +361,11 @@ describe 'tutor.card', ->
       eq err, null
       eq card.mana_cost, '{1}{B/P}'
 
+  it 'extracts mana cost containing colorless mana symbols',
+    card 'Kozilek, the Great Distortion', (err, card) ->
+      eq err, null
+      eq card.mana_cost, '{8}{C}{C}'
+
   it 'includes mana cost only if present',
     card 'Ancestral Vision', (err, card) ->
       eq err, null
@@ -404,6 +409,13 @@ describe 'tutor.card', ->
         {U/R}{U/R}, {Q}, Untap two tapped blue creatures you control: \
         Return target creature to its owner's hand. \
         ({Q} is the untap symbol.)
+      '''
+
+  it 'recognizes colorless mana symbols',
+    card 'Sol Ring', (err, card) ->
+      eq err, null
+      eq card.text, '''
+        {T}: Add {C}{C} to your mana pool.
       '''
 
   it 'extracts flavor text from card identified by id',


### PR DESCRIPTION
_Oath of the Gatewatch_ introduced the [colorless mana symbol][1].

<a href="http://gatherer.wizards.com/Pages/Card/Details.aspx?multiverseid=407514"><img alt="Kozilek, the Great Distortion" src="http://gatherer.wizards.com/Handlers/Image.ashx?multiverseid=407514&amp;type=card"></a> <a href="http://gatherer.wizards.com/Pages/Card/Details.aspx?multiverseid=40"><img alt="Sol Ring" src="http://gatherer.wizards.com/Handlers/Image.ashx?multiverseid=40&amp;type=card"></a>

This pull request adds support for `{C}` (via a one-line addition to [__symbols.coffee__][2]).


[1]: http://mtgsalvation.gamepedia.com/Colorless
[2]: https://github.com/davidchambers/tutor/blob/0.7.1/src/symbols.coffee
