### PR TITLE
travis: download fixtures in parallel

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,5 @@ node_js:
   - 10
   - 12
 install: npm install
-before_script: make clean fixtures
+before_script: make clean && make --jobs="$(nproc)" fixtures
 script: make test testcli

--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ tutor.types (err, types) ->
 
 ### Running the tests
 
-    $ make fixtures
+    $ make --jobs="$(nproc)" fixtures
     $ make test
     $ make testcli
 


### PR DESCRIPTION
I tested `--jobs="$(nproc)"` locally on my 8-core iMac Pro. It reduced the download time from eight minutes to about 40 seconds. :)
